### PR TITLE
Fix null permission when no permission is specified

### DIFF
--- a/src/main/java/com/github/tukenuke/tuske/util/CommandUtils.java
+++ b/src/main/java/com/github/tukenuke/tuske/util/CommandUtils.java
@@ -34,7 +34,7 @@ public class CommandUtils {
 		if (sender != null && cmd != null){
 			if (sender instanceof Player && perms != null && !sender.isOp()){
 				for (String perm : perms)
-					sender.addAttachment(TuSKe.getInstance(), perm, true, 0);
+					if (perm != null) sender.addAttachment(TuSKe.getInstance(), perm, true, 0);
 			}
 			if (cmd.startsWith("/"))
 				cmd = cmd.substring(1);


### PR DESCRIPTION
Adds a null check before adding the perm to the sender.
Fixes issues #24, #26 and #27.